### PR TITLE
Fixed removeObserveringDelegate so it does not skip over indices

### DIFF
--- a/src/GOSScrollViewDelegateMultiplexer.m
+++ b/src/GOSScrollViewDelegateMultiplexer.m
@@ -41,7 +41,7 @@
 }
 
 - (void)removeObservingDelegate:(id<UIScrollViewDelegate>)delegate {
-  for (NSUInteger i = 0; i < _observingDelegates.count; i++) {
+  for (NSInteger i = _observingDelegates.count -1; i >= 0; i--) {
     if ([_observingDelegates pointerAtIndex:i] == (__bridge void *)(delegate)) {
       [_observingDelegates removePointerAtIndex:i];
     }


### PR DESCRIPTION
 because of removed values.

Also refactored tests to remove XCTestExpecation's since they are not necessary. They also were not sufficient to check that a method was not called.
