### PR TITLE
Per issue #6 - Typo

### DIFF
--- a/examples/SVDMTypicalUseViewController.m
+++ b/examples/SVDMTypicalUseViewController.m
@@ -115,7 +115,7 @@
 - (UIView *)scrollViewDelegateMultiplexer:(GOSScrollViewDelegateMultiplexer *)multiplexer
                 viewForZoomingWithResults:(NSPointerArray *)results
                   fromRespondingObservers:(NSArray *)respondingObservers {
-  // Lets return the results from the oberserver which is equal to self.
+  // Lets return the results from the observer which is equal to self.
   if (respondingObservers[0] == self) {
     return [results pointerAtIndex:0];
   }


### PR DESCRIPTION
A very minor typo in the `SVDMTypicalUseViewController`
