### PR TITLE
Default Repo Branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MDFScrollViewDelegateMultiplexer
-[![Build Status](https://travis-ci.org/material-foundation/material-scrollview-delegate-multiplexer-ios.svg?branch=master)](https://travis-ci.org/material-foundation/material-scrollview-delegate-multiplexer-ios)
-[![Code Coverage](http://codecov.io/github/material-foundation/material-scrollview-delegate-multiplexer-ios/coverage.svg?branch=master)](http://codecov.io/github/material-foundation/material-scrollview-delegate-multiplexer-ios?branch=master)
+[![Build Status](https://travis-ci.org/material-foundation/material-scrollview-delegate-multiplexer-ios.svg?branch=develop)](https://travis-ci.org/material-foundation/material-scrollview-delegate-multiplexer-ios?branch=develop)
+[![Code Coverage](https://codecov.io/gh/material-foundation/material-scrollview-delegate-multiplexer-ios/branch/develop/graph/badge.svg)](http://codecov.io/github/material-foundation/material-scrollview-delegate-multiplexer-ios?branch=develop)
 
 This class acts as a proxy object for `UIScrollViewDelegate` events and forwards all received
 events to an ordered list of registered observers.


### PR DESCRIPTION
Apologies for the PR spam, but it looks like I got the link wrong for the code coverage in the README in https://github.com/material-foundation/material-scrollview-delegate-multiplexer-ios/pull/11.

Switching over to the default branch for the repo for both the build status and the code coverage.
